### PR TITLE
Form level validation

### DIFF
--- a/src/hooks/useMorfix.ts
+++ b/src/hooks/useMorfix.ts
@@ -1,12 +1,14 @@
 import { MutableRefObject, useCallback } from 'react';
+import merge from 'lodash/merge';
 import invariant from 'tiny-invariant';
 
 import { useMorfixStorage } from './useMorfixStorage';
-import { FieldValidator, MorfixErrors, SubmitAction } from '../typings';
+import { Empty, FieldValidator, MorfixErrors, SubmitAction } from '../typings';
 
 export type MorfixConfig<Values extends object> = {
     initialValues: Values;
     onSubmit?: SubmitAction<Values>;
+    validateForm?: FieldValidator<Values>;
 };
 
 export type FieldObservers<V> = {
@@ -25,7 +27,8 @@ export type MorfixShared<Values> = {
 
 export const useMorfix = <Values extends object>({
     initialValues,
-    onSubmit
+    onSubmit,
+    validateForm: validateFormFn
 }: MorfixConfig<Values>): MorfixShared<Values> => {
     const [
         { values, setFieldValue, observeValue, stopObservingValue, isValueObserved },
@@ -68,13 +71,20 @@ export const useMorfix = <Values extends object>({
         [stopObservingError, stopObservingValue, unregisterValidator]
     );
 
+    const validateForm = async (values: Values): Promise<MorfixErrors<Values>> => {
+        const registryErrors = await validateAllFields(values);
+        const validateFormFnErrors: MorfixErrors<Values> | Empty = await validateFormFn?.(values);
+
+        return merge(registryErrors, validateFormFnErrors);
+    };
+
     const submit = async (action: SubmitAction<Values> | undefined = onSubmit) => {
         invariant(
             action,
             'Cannot call submit, because no action specified in arguments and no default action provided.'
         );
 
-        const errors = await validateAllFields(values.current);
+        const errors = await validateForm(values.current);
 
         setFieldErrors(errors);
 

--- a/src/hooks/useMorfix.ts
+++ b/src/hooks/useMorfix.ts
@@ -33,15 +33,23 @@ export const useMorfix = <Values extends object>({
     const [
         { values, setFieldValue, observeValue, stopObservingValue, isValueObserved },
         { setFieldErrors, setFieldError, observeError, stopObservingError },
-        { validateField: runFieldLevelValidation, validateAllFields, registerValidator, unregisterValidator }
+        {
+            validateField: runFieldLevelValidation,
+            validateAllFields,
+            registerValidator,
+            unregisterValidator,
+            hasValidator
+        }
     ] = useMorfixStorage({ initialValues });
 
     const validateField = useCallback(
         async <V>(name: string, value: V) => {
-            const error = await runFieldLevelValidation(name, value);
-            setFieldError(name, error);
+            if (hasValidator(name)) {
+                const error = await runFieldLevelValidation(name, value);
+                setFieldError(name, error);
+            }
         },
-        [runFieldLevelValidation, setFieldError]
+        [runFieldLevelValidation, setFieldError, hasValidator]
     );
 
     const registerField = useCallback(

--- a/src/hooks/useValidationRegistry.ts
+++ b/src/hooks/useValidationRegistry.ts
@@ -13,6 +13,7 @@ export type ValidationRegistryControl = {
     unregisterValidator: <V>(name: string, validator: FieldValidator<V>) => void;
     validateField: <V>(name: string, value: V) => Promise<MorfixErrors<V> | undefined>;
     validateAllFields: <V extends object>(values: V) => Promise<MorfixErrors<V>>;
+    hasValidator: (name: string) => boolean;
 };
 
 export const useValidationRegistry = (): ValidationRegistryControl => {
@@ -43,6 +44,8 @@ export const useValidationRegistry = (): ValidationRegistryControl => {
         return undefined;
     };
 
+    const hasValidator = (name: string) => Object.prototype.hasOwnProperty.call(registry.current, name);
+
     const validateAllFields = async <V extends object>(values: V): Promise<MorfixErrors<V>> => {
         const reducedErrors: MorfixErrors<V> = {} as MorfixErrors<V>;
 
@@ -62,6 +65,7 @@ export const useValidationRegistry = (): ValidationRegistryControl => {
         registerValidator,
         unregisterValidator,
         validateField,
-        validateAllFields
+        validateAllFields,
+        hasValidator
     };
 };

--- a/src/typings/FieldValidator.ts
+++ b/src/typings/FieldValidator.ts
@@ -1,5 +1,5 @@
 import { MorfixErrors } from './MorfixErrors';
 
-type Empty = null | undefined | void;
+export type Empty = null | undefined | void;
 
 export type FieldValidator<V> = (value: V) => MorfixErrors<V> | Empty | Promise<MorfixErrors<V> | Empty>;


### PR DESCRIPTION
Created form-level validation #38 

Now, in useMorfix hook and Morfix component available prop `validateForm`. Usage:

```jsx
const TestForm = () => (
    <Morfix
        initialValues={{ a: 'asdf' }}
        validateForm={(values) => {
            alert('Form-level validation!!!');
            // you can use all values for validation
        }}
    >
        <div>This is form!</div>
    </Morfix>
);
```